### PR TITLE
build: fix install path for switchboard plug

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,9 @@ gettext_name = meson.project_name() + '-plug'
 gnome = import('gnome')
 i18n = import('i18n')
 
+prefix = get_option('prefix')
+libdir = join_paths(prefix, get_option('libdir'))
+
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     language:'c'

--- a/src/meson.build
+++ b/src/meson.build
@@ -4,6 +4,7 @@ plug_files = files(
 )
 
 switchboard_dep = dependency('switchboard-2.0')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
 shared_module(
     meson.project_name(),
@@ -15,6 +16,6 @@ shared_module(
         switchboard_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal')
+    install_dir : join_paths(switchboard_plugsdir, 'personal')
 )
 


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this switchboard_dep.get_pkgconfig_variable will return a
path from within switchboard's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.